### PR TITLE
Add adjustable padding for nested nodes and add storybook story for custom nested nodes

### DIFF
--- a/src/layout/elkLayout.ts
+++ b/src/layout/elkLayout.ts
@@ -33,10 +33,7 @@ function mapNode(nodes: NodeData[], edges: EdgeData[], node: NodeData) {
     height,
     labelHeight,
     labelWidth,
-    paddingTop,
-    paddingRight,
-    paddingBottom,
-    paddingLeft,
+    nodePadding,
     originalText
   } = formatText(node);
 
@@ -65,7 +62,7 @@ function mapNode(nodes: NodeData[], edges: EdgeData[], node: NodeData) {
       }))
       : [],
     layoutOptions: {
-      'elk.padding': `[left=${paddingLeft}, top=${paddingTop}, right=${paddingRight}, bottom=${paddingBottom}]`,
+      'elk.padding': `[left=${nodePadding.left}, top=${nodePadding.top}, right=${nodePadding.right}, bottom=${nodePadding.bottom}]`,
       portConstraints: 'FIXED_ORDER'
     },
     properties: {

--- a/src/layout/elkLayout.ts
+++ b/src/layout/elkLayout.ts
@@ -33,6 +33,10 @@ function mapNode(nodes: NodeData[], edges: EdgeData[], node: NodeData) {
     height,
     labelHeight,
     labelWidth,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
     originalText
   } = formatText(node);
 
@@ -61,7 +65,7 @@ function mapNode(nodes: NodeData[], edges: EdgeData[], node: NodeData) {
       }))
       : [],
     layoutOptions: {
-      'elk.padding': '[left=50, top=50, right=50, bottom=50]',
+      'elk.padding': `[left=${paddingLeft}, top=${paddingTop}, right=${paddingRight}, bottom=${paddingBottom}]`,
       portConstraints: 'FIXED_ORDER'
     },
     properties: {

--- a/src/layout/utils.test.ts
+++ b/src/layout/utils.test.ts
@@ -1,0 +1,32 @@
+import { parsePadding } from './utils';
+jest.disableAutomock();
+
+test('should set all sides to input number, when a number is provided', () => {
+  const expectedPadding = {
+    top: 10,
+    right: 10,
+    bottom: 10,
+    left: 10
+  };
+  expect(parsePadding(10)).toEqual(expectedPadding);
+});
+
+test('should set horizontal and vertical padding, when an array with numbers is provided', () => {
+  const expectedPadding = {
+    top: 20,
+    right: 50,
+    bottom: 20,
+    left: 50
+  };
+  expect(parsePadding([20, 50])).toEqual(expectedPadding);
+});
+
+test('should set each padding value individually, when an array with four numbers is provided', () => {
+  const expectedPadding = {
+    top: 20,
+    right: 50,
+    bottom: 100,
+    left: 150
+  };
+  expect(parsePadding([20, 50, 100, 150])).toEqual(expectedPadding);
+});

--- a/src/layout/utils.ts
+++ b/src/layout/utils.ts
@@ -21,7 +21,7 @@ export function measureText(text: string) {
   return result;
 }
 
-function parsePadding(padding?: number[]) {
+function parsePadding(padding: NodeData['nodePadding']) {
   let top = 50;
   let right = 50;
   let bottom = 50;

--- a/src/layout/utils.ts
+++ b/src/layout/utils.ts
@@ -21,7 +21,7 @@ export function measureText(text: string) {
   return result;
 }
 
-function parsePadding(padding: NodeData['nodePadding']) {
+export function parsePadding(padding: NodeData['nodePadding']) {
   let top = 50;
   let right = 50;
   let bottom = 50;

--- a/src/layout/utils.ts
+++ b/src/layout/utils.ts
@@ -22,9 +22,7 @@ export function measureText(text: string) {
 }
 
 export function formatText(node: NodeData) {
-  const text = node.text
-    ? ellipsize(node.text, MAX_CHAR_COUNT)
-    : node.text;
+  const text = node.text ? ellipsize(node.text, MAX_CHAR_COUNT) : node.text;
 
   const labelDim = measureText(text);
 
@@ -61,6 +59,10 @@ export function formatText(node: NodeData) {
     originalText: node.text,
     width,
     height,
+    paddingTop: node.paddingTop || 50,
+    paddingRight: node.paddingRight || 50,
+    paddingBottom: node.paddingBottom || 50,
+    paddingLeft: node.paddingLeft || 50,
     labelHeight: labelDim.height,
     labelWidth: labelDim.width
   };

--- a/src/layout/utils.ts
+++ b/src/layout/utils.ts
@@ -21,10 +21,44 @@ export function measureText(text: string) {
   return result;
 }
 
+function parsePadding(padding?: number[]) {
+  let top = 50;
+  let right = 50;
+  let bottom = 50;
+  let left = 50;
+
+  if (Array.isArray(padding)) {
+    if (padding.length === 2) {
+      top = padding[0];
+      bottom = padding[0];
+      left = padding[1];
+      right = padding[1];
+    } else if (padding.length === 4) {
+      top = padding[0];
+      right = padding[1];
+      bottom = padding[2];
+      left = padding[3];
+    }
+  } else if (padding !== undefined) {
+    top = padding;
+    right = padding;
+    bottom = padding;
+    left = padding;
+  }
+
+  return {
+    top,
+    right,
+    bottom,
+    left
+  };
+}
+
 export function formatText(node: NodeData) {
   const text = node.text ? ellipsize(node.text, MAX_CHAR_COUNT) : node.text;
 
   const labelDim = measureText(text);
+  const nodePadding = parsePadding(node.nodePadding);
 
   let width = node.width;
   if (width === undefined) {
@@ -59,10 +93,7 @@ export function formatText(node: NodeData) {
     originalText: node.text,
     width,
     height,
-    paddingTop: node.paddingTop || 50,
-    paddingRight: node.paddingRight || 50,
-    paddingBottom: node.paddingBottom || 50,
-    paddingLeft: node.paddingLeft || 50,
+    nodePadding,
     labelHeight: labelDim.height,
     labelWidth: labelDim.width
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,7 @@ export interface NodeData<T = any> {
   parent?: string;
   ports?: PortData[];
   icon?: IconData;
-  paddingTop?: number;
-  paddingLeft?: number;
-  paddingRight?: number;
-  paddingBottom?: number;
+  nodePadding?: [number];
   data?: T;
   className?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface NodeData<T = any> {
   parent?: string;
   ports?: PortData[];
   icon?: IconData;
-  nodePadding?: [number];
+  nodePadding?: [number, number] | [number, number, number, number] | number;
   data?: T;
   className?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface NodeData<T = any> {
   parent?: string;
   ports?: PortData[];
   icon?: IconData;
-  nodePadding?: [number, number] | [number, number, number, number] | number;
+  nodePadding?: number | [number, number] | [number, number, number, number];
   data?: T;
   className?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,10 @@ export interface NodeData<T = any> {
   parent?: string;
   ports?: PortData[];
   icon?: IconData;
+  paddingTop?: number;
+  paddingLeft?: number;
+  paddingRight?: number;
+  paddingBottom?: number;
   data?: T;
   className?: string;
 }

--- a/stories/Basic.stories.tsx
+++ b/stories/Basic.stories.tsx
@@ -112,31 +112,50 @@ export const CustomElements = () => (
     <Canvas
       nodes={[
         {
-          id: '1',
-          text: 'Node 1'
+          id: '2',
+          text: 'Mother',
+          data: {
+            "gender": "female"
+          }
         },
         {
-          id: '2',
-          text: 'Node 2'
-        }
+          id: '3',
+          text: 'Daughter',
+          data: {
+            "gender": "female"
+          }
+        },
+        {
+          id: '4',
+          text: 'Son',
+          data: {
+            "gender": "male"
+          }
+        },
       ]}
       edges={[
         {
-          id: '1-2',
-          from: '1',
-          to: '2'
+          id: '2-3',
+          from: '2',
+          to: '3'
+        },
+        {
+          id: '2-4',
+          from: '2',
+          to: '4'
         }
       ]}
       node={(node: NodeProps) => (
         <Node
           {...node}
-          style={{ fill: node.id === '1' ? 'blue' : 'green' }}
+          onClick={() => console.log(node.properties.data)}
+          style={{ fill: node.properties.data?.gender === 'male' ? 'blue' : 'red' }}
         />
       )}
       edge={(edge: EdgeProps) => (
         <Edge
           {...edge}
-          style={{ stroke: edge.id === '1-2' ? 'blue' : 'green' }}
+          style={{ stroke: edge.id === '2-4' ? 'blue' : 'red' }}
         />
       )}
       onLayoutChange={layout => console.log('Layout', layout)}

--- a/stories/Nested.stories.tsx
+++ b/stories/Nested.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Canvas } from '../src/Canvas';
-import { Node, Edge, MarkerArrow, Port, Icon, Arrow, Label, Remove, Add } from '../src/symbols';
+import { Node, Edge, MarkerArrow, Port, Icon, Arrow, Label, Remove, Add, NodeProps } from '../src/symbols';
 import { EdgeData, NodeData } from '../src/types';
 
 export const Simple = () => (
@@ -96,6 +96,110 @@ export const Linking = () => {
           ]);
         }}
         onLayoutChange={layout => console.log('Layout', layout)}
+      />
+    </div>
+  );
+};
+
+export const NestedLinking = () => {
+  const nodeDimensions : any = {
+    typeA: {
+      width: 190,
+      height: 150
+    },
+    typeB:{
+      width: 80,
+      height: 80
+    }
+  }
+  const nodes = [
+    { 
+      id: '1', 
+      text: '1',
+    },
+    { 
+      id: '2',
+      label: 'A',
+      name: 'Process XYZ',
+      description: 'Description of XYZ',
+      //describes padding for nested nodes
+      paddingTop: 120,
+      ...nodeDimensions.typeA
+    },
+    { 
+      id: '2.1',
+      parent: '2',
+      label: 'B',
+      name: 'Task 1',
+      ...nodeDimensions.typeB
+    },
+    { 
+      id: '2.2', 
+      parent: '2', 
+      label: 'B',
+      name: 'Task 2',
+      ...nodeDimensions.typeB
+    },
+    { 
+      id: '3',
+      text: '3'
+    }
+  ];
+  const edges = [
+    {
+      id: '1-2.1', 
+      from: '1', 
+      to: '2.1' 
+    }, 
+    { 
+      id: '2.1-2.2', 
+      parent: '2',
+      from: '2.1', 
+      to: '2.2' 
+    }, 
+    { 
+      id: '2.2-3', 
+      from: '2.2', 
+      to: '3' 
+    },
+  ];
+
+  function prepareNode(node){
+    const data = node.properties;
+    switch (data.label){
+      case 'A':
+        return (
+          <Node style={{fill: 'lightgreen', opacity: 0.8}}>
+            <div style={{textAlign: "center"}}>
+              <h4>{data.name}</h4>
+              <p>{data.description}</p>
+            </div>
+          </Node>
+        )
+      case 'B':
+        return (
+          <Node style={{fill: 'lightyellow'}}>
+            <div style={{textAlign: "center"}}>
+              <h4>{data.name}</h4>
+            </div>
+          </Node>
+        )
+      default:
+        return (
+          <Node/>
+        )
+    }
+  }
+
+  return (
+    <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}>
+      <Canvas
+        //required to enable edges from/to nested nodes
+        layoutOptions={{'elk.hierarchyHandling':'INCLUDE_CHILDREN'}}
+        direction="RIGHT"
+        nodes={nodes}
+        edges={edges}
+        node={(node: NodeProps) => prepareNode(node)}
       />
     </div>
   );

--- a/stories/Nested.stories.tsx
+++ b/stories/Nested.stories.tsx
@@ -101,7 +101,7 @@ export const Linking = () => {
   );
 };
 
-export const NestedLinking = () => {
+export const NestedEdges = () => {
   const nodeDimensions : any = {
     typeA: {
       width: 190,
@@ -112,7 +112,7 @@ export const NestedLinking = () => {
       height: 80
     }
   }
-  const nodes = [
+  const nodes: NodeData[]= [
     { 
       id: '1', 
       text: '1',
@@ -122,8 +122,8 @@ export const NestedLinking = () => {
       label: 'A',
       name: 'Process XYZ',
       description: 'Description of XYZ',
-      //describes padding for nested nodes
-      paddingTop: 120,
+      // describes padding for nested nodes
+      nodePadding: [120, 50, 50, 50],
       ...nodeDimensions.typeA
     },
     { 
@@ -145,7 +145,7 @@ export const NestedLinking = () => {
       text: '3'
     }
   ];
-  const edges = [
+  const edges: EdgeData[] = [
     {
       id: '1-2.1', 
       from: '1', 
@@ -194,7 +194,7 @@ export const NestedLinking = () => {
   return (
     <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}>
       <Canvas
-        //required to enable edges from/to nested nodes
+        // required to enable edges from/to nested nodes
         layoutOptions={{'elk.hierarchyHandling':'INCLUDE_CHILDREN'}}
         direction="RIGHT"
         nodes={nodes}

--- a/stories/Nested.stories.tsx
+++ b/stories/Nested.stories.tsx
@@ -196,7 +196,7 @@ export const NestedEdges = () => {
       <Canvas
         // required to enable edges from/to nested nodes
         layoutOptions={{'elk.hierarchyHandling':'INCLUDE_CHILDREN'}}
-        direction="RIGHT"
+        direction='RIGHT'
         nodes={nodes}
         edges={edges}
         node={(node: NodeProps) => prepareNode(node)}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The node content might get "covered" by nested nodes and there is currently no way to provide a padding for nodes within a node.

Issue Number: #28 


## What is the new behavior?
The padding towards nested nodes can now be adjusted for individual nodes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Naming might be ambigous - Open for suggestions! maybe "innerPadding" or "nestedPadding" is more intuitive, because the actual node content is not affected by the padding.
