### PR TITLE
adjust the `upsertNode` function to update edges that are within groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
       ".(ts|tsx)": "ts-jest"
     },
     "testMatch": [
-      "<rootDir>/src/**/?(*.)(spec|test).ts?(x)"
+      "<rootDir>/src/**/*.(spec|test).ts?(x)"
     ],
     "transformIgnorePatterns": [
       "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"

--- a/src/helpers/crudHelpers.test.ts
+++ b/src/helpers/crudHelpers.test.ts
@@ -1,0 +1,69 @@
+import { upsertNode } from './crudHelpers';
+
+const nodes = [
+  {
+    id: '1'
+  },
+  {
+    id: '2',
+    text: 'Node 2',
+    parent: '1'
+  },
+  {
+    id: '3',
+    text: 'Node 3',
+    parent: '1'
+  },
+  {
+    id: '4',
+    text: 'Node 4',
+    parent: '1'
+  }
+];
+const edges = [
+  {
+    id: '2-3',
+    from: '2',
+    to: '3',
+    parent: '1'
+  },
+  {
+    id: '2-4',
+    from: '2',
+    to: '4',
+    parent: '1'
+  }
+];
+
+test('should upsert node with edges using properties from original one and in right order', () => {
+  const newNode = {
+    id: '5',
+    text: 'Node 5',
+    parent: '1'
+  };
+  const expectedResults = {
+    nodes: nodes.concat(newNode),
+    edges: [
+      {
+        id: '2-5',
+        from: '2',
+        to: '5',
+        parent: '1'
+      },
+      {
+        id: '5-3',
+        from: '5',
+        to: '3',
+        parent: '1'
+      },
+      {
+        id: '2-4',
+        from: '2',
+        to: '4',
+        parent: '1'
+      }
+    ]
+  };
+
+  expect(upsertNode(nodes, edges, edges[0], newNode)).toEqual(expectedResults);
+});

--- a/src/helpers/crudHelpers.ts
+++ b/src/helpers/crudHelpers.ts
@@ -9,21 +9,31 @@ export function upsertNode(
   edge: EdgeData,
   newNode: NodeData
 ) {
+  const oldEdgeIndex = edges.findIndex((e) => e.id === edge.id);
+  const edgeBeforeNewNode = {
+    ...edge,
+    id: `${edge.from}-${newNode.id}`,
+    to: newNode.id
+  };
+  const edgeAfterNewNode = {
+    ...edge,
+    id: `${newNode.id}-${edge.to}`,
+    from: newNode.id
+  };
+
+  if (edge.fromPort && edge.toPort) {
+    edgeBeforeNewNode.fromPort = edge.fromPort;
+    edgeBeforeNewNode.toPort = `${newNode.id}-to`;
+
+    edgeAfterNewNode.fromPort = `${newNode.id}-from`;
+    edgeAfterNewNode.toPort = edge.toPort;
+  }
+
+  edges.splice(oldEdgeIndex, 1, edgeBeforeNewNode, edgeAfterNewNode);
+
   return {
     nodes: [...nodes, newNode],
-    edges: [
-      ...edges.filter((e) => e.id !== edge.id),
-      {
-        id: `${edge.from}-${newNode.id}`,
-        from: edge.from,
-        to: newNode.id
-      },
-      {
-        id: `${newNode.id}-${edge.to}`,
-        from: newNode.id,
-        to: edge.to
-      }
-    ]
+    edges: [...edges]
   };
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#37]


## What is the new behavior?
Newly created edges from `upsertNode` will take properties from the original edge and will be inserted in the right place

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
