### PR TITLE
Add `children` property to Edges/Port components

### DIFF
--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -109,9 +109,9 @@ export const Edge: FC<Partial<EdgeProps>> = ({
   const [deleteHovered, setDeleteHovered] = useState<boolean>(false);
   const [center, setCenter] = useState<CenterCoords | null>(null);
   const { selections, readonly } = useCanvas();
-  const isActive = selections?.length
+  const isActive: boolean = selections?.length
     ? selections.includes(properties?.id)
-    : null;
+    : false;
 
   // The "d" attribute defines a path to be drawn. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d
   const d = useMemo(() => {

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -1,6 +1,9 @@
 import React, {
   FC,
+  Fragment,
+  MutableRefObject,
   ReactElement,
+  ReactNode,
   useEffect,
   useMemo,
   useRef,
@@ -33,6 +36,16 @@ export interface EdgeSections {
   };
 }
 
+export interface EdgeChildProps {
+  edge: EdgeData;
+  pathRef: MutableRefObject<SVGPathElement> | null;
+  center: CenterCoords | null;
+}
+
+export type EdgeChildrenAsFunction = (
+  edgeChildProps: EdgeChildProps
+) => ReactNode;
+
 export interface EdgeProps {
   id: string;
   disabled?: boolean;
@@ -42,6 +55,7 @@ export interface EdgeProps {
   targetPort: string;
   properties?: EdgeData;
   style?: any;
+  children?: ReactNode | EdgeChildrenAsFunction;
   sections: EdgeSections[];
   labels?: LabelProps[];
   className?: string;
@@ -80,6 +94,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
   className,
   disabled,
   style,
+  children,
   add = <Add />,
   remove = <Remove />,
   label = <Label />,
@@ -143,6 +158,12 @@ export const Edge: FC<Partial<EdgeProps>> = ({
     }
   }, [sections]);
 
+  const edgeChildProps: EdgeChildProps = {
+    edge: properties,
+    center,
+    pathRef
+  };
+
   return (
     <g
       className={classNames(css.edge, {
@@ -184,6 +205,14 @@ export const Edge: FC<Partial<EdgeProps>> = ({
           onLeave(event, properties);
         }}
       />
+
+      {children && (
+        <Fragment>
+          {typeof children === 'function'
+            ? (children as EdgeChildrenAsFunction)(edgeChildProps)
+            : children}
+        </Fragment>
+      )}
 
       {labels?.length > 0 &&
         labels.map((l, index) => (

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -98,6 +98,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
     ? selections.includes(properties?.id)
     : null;
 
+  // The "d" attribute defines a path to be drawn. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d
   const d = useMemo(() => {
     if (!sections?.length) {
       return null;
@@ -159,6 +160,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
         d={d}
         markerEnd="url(#end-arrow)"
       />
+
       <path
         className={css.clicker}
         d={d}
@@ -182,6 +184,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
           onLeave(event, properties);
         }}
       />
+
       {labels?.length > 0 &&
         labels.map((l, index) => (
           <CloneElement<LabelProps>
@@ -190,6 +193,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
             {...(l as LabelProps)}
           />
         ))}
+
       {!disabled && center && !readonly && remove && (
         <CloneElement<RemoveProps>
           element={remove}
@@ -207,6 +211,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
           onLeave={() => setDeleteHovered(false)}
         />
       )}
+
       {!disabled && center && !readonly && add && (
         <CloneElement<AddProps>
           element={add}

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -104,7 +104,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
     }
 
     // Handle bend points that elk gives
-    // us seperately from drag points
+    // us separately from drag points
     if (sections[0].bendPoints) {
       const points: any[] = sections
         ? [

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -181,7 +181,6 @@ export const Edge: FC<Partial<EdgeProps>> = ({
         d={d}
         markerEnd="url(#end-arrow)"
       />
-
       <path
         className={css.clicker}
         d={d}
@@ -205,7 +204,6 @@ export const Edge: FC<Partial<EdgeProps>> = ({
           onLeave(event, properties);
         }}
       />
-
       {children && (
         <Fragment>
           {typeof children === 'function'
@@ -213,7 +211,6 @@ export const Edge: FC<Partial<EdgeProps>> = ({
             : children}
         </Fragment>
       )}
-
       {labels?.length > 0 &&
         labels.map((l, index) => (
           <CloneElement<LabelProps>
@@ -222,7 +219,6 @@ export const Edge: FC<Partial<EdgeProps>> = ({
             {...(l as LabelProps)}
           />
         ))}
-
       {!disabled && center && !readonly && remove && (
         <CloneElement<RemoveProps>
           element={remove}
@@ -240,7 +236,6 @@ export const Edge: FC<Partial<EdgeProps>> = ({
           onLeave={() => setDeleteHovered(false)}
         />
       )}
-
       {!disabled && center && !readonly && add && (
         <CloneElement<AddProps>
           element={add}

--- a/src/symbols/Node/Node.module.css
+++ b/src/symbols/Node/Node.module.css
@@ -1,8 +1,6 @@
 .rect {
   fill: #2b2c3e;
   transition: stroke 100ms ease-in-out;
-  /* TODO Why duplicated stroke? */
-  stroke: transparent;
   stroke: #475872;
   shape-rendering: geometricPrecision;
   stroke-width: 1pt;

--- a/src/symbols/Node/Node.module.css
+++ b/src/symbols/Node/Node.module.css
@@ -1,7 +1,8 @@
 .rect {
   fill: #2b2c3e;
-  stroke: transparent;
   transition: stroke 100ms ease-in-out;
+  /* TODO Why duplicated stroke? */
+  stroke: transparent;
   stroke: #475872;
   shape-rendering: geometricPrecision;
   stroke-width: 1pt;

--- a/src/symbols/Node/Node.tsx
+++ b/src/symbols/Node/Node.tsx
@@ -242,7 +242,7 @@ export const Node: FC<Partial<NodeProps>> = ({
               node: properties,
               nodes,
               edges
-            })
+            } as NodeChildProps)
             : children}
         </Fragment>
       )}

--- a/src/symbols/Node/Node.tsx
+++ b/src/symbols/Node/Node.tsx
@@ -3,9 +3,7 @@ import React, {
   Fragment,
   ReactElement,
   ReactNode,
-  useCallback,
   useEffect,
-  useRef,
   useState
 } from 'react';
 import { motion, useAnimation } from 'framer-motion';
@@ -37,6 +35,10 @@ export interface NodeChildProps {
   edges?: EdgeData[];
 }
 
+export type NodeChildrenAsFunction = (
+  nodeChildProps: NodeChildProps
+) => ReactNode;
+
 export interface NodeProps extends NodeDragEvents<NodeData, PortData> {
   id: string;
   height: number;
@@ -53,7 +55,7 @@ export interface NodeProps extends NodeDragEvents<NodeData, PortData> {
   properties: any;
   className?: string;
   style?: any;
-  children?: ReactNode | ((node: NodeChildProps) => ReactNode);
+  children?: ReactNode | NodeChildrenAsFunction;
   parent?: string;
 
   nodes?: NodeData[];
@@ -174,6 +176,16 @@ export const Node: FC<Partial<NodeProps>> = ({
     });
   }, [controls, x, y]);
 
+  const nodeChildProps: NodeChildProps = {
+    height,
+    width,
+    x,
+    y,
+    node: properties,
+    nodes,
+    edges
+  };
+
   return (
     <motion.g
       initial={{
@@ -234,15 +246,7 @@ export const Node: FC<Partial<NodeProps>> = ({
       {children && (
         <Fragment>
           {typeof children === 'function'
-            ? (children as any)({
-              height,
-              width,
-              x,
-              y,
-              node: properties,
-              nodes,
-              edges
-            } as NodeChildProps)
+            ? (children as NodeChildrenAsFunction)(nodeChildProps)
             : children}
         </Fragment>
       )}

--- a/src/symbols/Port/Port.tsx
+++ b/src/symbols/Port/Port.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Ref, useState } from 'react';
+import React, { forwardRef, Fragment, ReactNode, Ref, useState } from 'react';
 import { motion } from 'framer-motion';
 import { PortData } from '../../types';
 import {
@@ -19,6 +19,23 @@ export interface ElkPortProperties {
   'port.alignment': string;
 }
 
+export interface PortChildProps {
+  port: PortData;
+  isDisabled: boolean;
+  isDragging: boolean;
+  isHovered: boolean;
+  x: number;
+  y: number;
+  rx: number;
+  ry: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+export type PortChildrenAsFunction = (
+  portChildProps: PortChildProps
+) => ReactNode;
+
 export interface PortProps extends NodeDragEvents<PortData> {
   id: string;
   x: number;
@@ -31,6 +48,7 @@ export interface PortProps extends NodeDragEvents<PortData> {
   className?: string;
   properties: ElkPortProperties & PortData;
   style?: any;
+  children?: ReactNode | PortChildrenAsFunction;
   active?: boolean;
   onEnter?: (
     event: React.MouseEvent<SVGGElement, MouseEvent>,
@@ -55,6 +73,7 @@ export const Port = forwardRef(
       ry,
       disabled,
       style,
+      children,
       properties,
       offsetX,
       offsetY,
@@ -103,6 +122,19 @@ export const Port = forwardRef(
 
     const isDisabled = properties.disabled || disabled;
 
+    const portChildProps: PortChildProps = {
+      port: properties,
+      isDragging: dragging,
+      isHovered: hovered,
+      isDisabled,
+      x,
+      y,
+      rx,
+      ry,
+      offsetX,
+      offsetY
+    };
+
     return (
       <g>
         <rect
@@ -128,6 +160,7 @@ export const Port = forwardRef(
             onClick(event, properties);
           }}
         />
+
         <motion.rect
           key={`${x}-${y}`}
           style={style}
@@ -149,6 +182,14 @@ export const Port = forwardRef(
             opacity: 1
           }}
         />
+
+        {children && (
+          <Fragment>
+            {typeof children === 'function'
+              ? (children as PortChildrenAsFunction)(portChildProps)
+              : children}
+          </Fragment>
+        )}
       </g>
     );
   }

--- a/src/symbols/Port/Port.tsx
+++ b/src/symbols/Port/Port.tsx
@@ -160,7 +160,6 @@ export const Port = forwardRef(
             onClick(event, properties);
           }}
         />
-
         <motion.rect
           key={`${x}-${y}`}
           style={style}
@@ -182,7 +181,6 @@ export const Port = forwardRef(
             opacity: 1
           }}
         />
-
         {children && (
           <Fragment>
             {typeof children === 'function'

--- a/src/symbols/Port/Port.tsx
+++ b/src/symbols/Port/Port.tsx
@@ -89,19 +89,19 @@ export const Port = forwardRef(
     ref: Ref<SVGRectElement>
   ) => {
     const { readonly } = useCanvas();
-    const [dragging, setDragging] = useState<boolean>(false);
-    const [hovered, setHovered] = useState<boolean>(false);
+    const [isDragging, setIsDragging] = useState<boolean>(false);
+    const [isHovered, setIsHovered] = useState<boolean>(false);
     const newX = x - properties.width / 2;
     const newY = y - properties.height / 2;
 
     const onDragStartInternal = (event: DragEvent, initial: Position) => {
       onDragStart(event, initial, properties);
-      setDragging(true);
+      setIsDragging(true);
     };
 
     const onDragEndInternal = (event: DragEvent, initial: Position) => {
       onDragEnd(event, initial, properties);
-      setDragging(false);
+      setIsDragging(false);
     };
 
     const bind = useNodeDrag({
@@ -124,8 +124,8 @@ export const Port = forwardRef(
 
     const portChildProps: PortChildProps = {
       port: properties,
-      isDragging: dragging,
-      isHovered: hovered,
+      isDragging,
+      isHovered,
       isDisabled,
       x,
       y,
@@ -147,12 +147,12 @@ export const Port = forwardRef(
           className={classNames(css.clicker, { [css.disabled]: isDisabled })}
           onMouseEnter={(event) => {
             event.stopPropagation();
-            setHovered(true);
+            setIsHovered(true);
             onEnter(event, properties);
           }}
           onMouseLeave={(event) => {
             event.stopPropagation();
-            setHovered(false);
+            setIsHovered(false);
             onLeave(event, properties);
           }}
           onClick={(event) => {
@@ -178,7 +178,7 @@ export const Port = forwardRef(
           animate={{
             x: newX,
             y: newY,
-            scale: (dragging || active || hovered) && !isDisabled ? 1.5 : 1,
+            scale: (isDragging || active || isHovered) && !isDisabled ? 1.5 : 1,
             opacity: 1
           }}
         />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Using `children` isn't currently possible for Edge/Port components.

Issue Number: 
- #67


## What is the new behavior?

Using `children` is now possible for Edge/Port components.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

New capabilities:
- Using `children` to display custom React components at the center of an edge.
- Using `children` to display custom React components close to a port.

Used by https://github.com/Vadorequest/poc-nextjs-reaflow/pull/4 to display the following:

![image](https://user-images.githubusercontent.com/3807458/109295241-b1b21980-782e-11eb-8d3b-e836e76003e1.png)

---

Depends on https://github.com/reaviz/reaflow/pull/69 for adding component tests.
Fixes https://github.com/reaviz/reaflow/issues/67