### PR TITLE
Drag node edge callback

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -166,9 +166,7 @@ export interface CanvasProps {
   /**
    * Element of the drag edge.
    */
-  dragEdge?:
-    | ReactElement<EdgeProps, typeof Edge>
-    | ((edge: EdgeProps) => ReactElement<NodeProps, typeof Edge>);
+  dragEdge?: ReactElement<EdgeProps, typeof Edge>;
 
   /**
    * Element of the drag node.

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -277,6 +277,13 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
     const [dragNodeDataWithChildren, setDragNodeDataWithChildren] = useState<{
       [key: string]: any;
     }>(dragNodeData);
+    const dragNodeElement = useMemo(
+      () =>
+        typeof dragNode === 'function'
+          ? dragNode(dragNodeData as NodeProps)
+          : dragNode,
+      [dragNode, dragNodeData]
+    );
     useLayoutEffect(() => {
       if (!mount.current && layout !== null && xy[0] > 0 && xy[1] > 0) {
         mount.current = true;
@@ -322,15 +329,9 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
 
     useEffect(() => {
       if (dragNodeData && Object.keys(dragNodeData).length > 0) {
-        // Generate the JSX node element based on the dragNodeData
-        const element =
-          typeof dragNode === 'function'
-            ? dragNode(dragNodeData as NodeProps)
-            : dragNode;
         const nodeCopy = { ...dragNodeData };
         // Node children is expecting a list of React Elements, need to create a list of elements
         nodeCopy.children = createDragNodeChildren(nodeCopy.children);
-        nodeCopy.element = element;
         setDragNodeDataWithChildren(nodeCopy);
       }
     }, [createDragNodeChildren, dragNode, dragNodeData, layout?.children]);
@@ -461,7 +462,7 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
               !readonly && (
               <CloneElement<NodeProps>
                 {...dragNodeDataWithChildren}
-                element={dragNodeDataWithChildren.element}
+                element={dragNodeElement}
                 height={
                   dragNodeDataWithChildren?.props?.height ||
                     dragNodeDataWithChildren?.height

--- a/stories/Drag.stories.tsx
+++ b/stories/Drag.stories.tsx
@@ -465,7 +465,6 @@ export const NestedNodeRearranging = () => {
         nodes={nodes}
         edges={edges}
         node={<Node dragType="node" />}
-        dragNode={(node: NodeProps) => (<Node {...node} dragType="node" />)}
         onNodeLinkCheck={(_event, from: NodeData, to: NodeData) => {
           if (from.id === to.id) {
             return false;

--- a/stories/Drag.stories.tsx
+++ b/stories/Drag.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Canvas } from '../src/Canvas';
-import { Node, Edge, MarkerArrow, Port, Icon, Arrow, Label, Remove, Add, NodeProps } from '../src/symbols';
+import { Node, Edge, MarkerArrow, Port, Icon, Arrow, Label, Remove, Add } from '../src/symbols';
 import { EdgeData, NodeData } from '../src/types';
 import { createEdgeFromNodes, hasLink, removeAndUpsertNodes } from '../src/helpers';
 

--- a/stories/Drag.stories.tsx
+++ b/stories/Drag.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Canvas } from '../src/Canvas';
-import { Node, Edge, MarkerArrow, Port, Icon, Arrow, Label, Remove, Add } from '../src/symbols';
+import { Node, Edge, MarkerArrow, Port, Icon, Arrow, Label, Remove, Add, NodeProps } from '../src/symbols';
 import { EdgeData, NodeData } from '../src/types';
 import { createEdgeFromNodes, hasLink, removeAndUpsertNodes } from '../src/helpers';
 
@@ -465,6 +465,7 @@ export const NestedNodeRearranging = () => {
         nodes={nodes}
         edges={edges}
         node={<Node dragType="node" />}
+        dragNode={(node: NodeProps) => (<Node {...node} dragType="node" />)}
         onNodeLinkCheck={(_event, from: NodeData, to: NodeData) => {
           if (from.id === to.id) {
             return false;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Error is thrown when a dragNode or dragEdge callback is used for overriding the drag.
Issue Number: N/A


## What is the new behavior?
Remove `dragEdge` callback option. Get the node props of the dragging node to use with the `dragNode` callback function.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
