### PR TITLE
fix finding deeply nested nodes

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -84,12 +84,14 @@ export function findNestedNode(
   }
 
   // Check for nested children
-  const nodesWithChildren = children.filter(n => n.children);
+  const nodesWithChildren = children.filter(
+    n => n.children && n.children.length > 0
+  );
   // Iterate over all nested nodes and check if any of them contain the node
   for (const n of nodesWithChildren) {
     const foundChild = findNestedNode(nodeId, n.children, parentId);
 
-    if (foundChild) {
+    if (foundChild && Object.keys(foundChild).length > 0) {
       return foundChild;
     }
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -85,7 +85,7 @@ export function findNestedNode(
 
   // Check for nested children
   const nodesWithChildren = children.filter(
-    n => n.children && n.children.length > 0
+    n => n.children?.length
   );
   // Iterate over all nested nodes and check if any of them contain the node
   for (const n of nodesWithChildren) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -91,7 +91,7 @@ export function findNestedNode(
   for (const n of nodesWithChildren) {
     const foundChild = findNestedNode(nodeId, n.children, parentId);
 
-    if (foundChild && Object.keys(foundChild).length > 0) {
+    if (foundChild && Object.keys(foundChild).length) {
       return foundChild;
     }
   }

--- a/stories/Drag.stories.tsx
+++ b/stories/Drag.stories.tsx
@@ -423,6 +423,15 @@ export const NestedNodeRearranging = () => {
       parent: '2'
     },
     {
+      id: '2-2-1',
+      parent: '2'
+    },
+    {
+      id: '2-2-1-1',
+      text: '2 > 2.1 > 1.1',
+      parent: '2-2-1'
+    },
+    {
       id: '3',
       text: '3'
     }
@@ -444,6 +453,12 @@ export const NestedNodeRearranging = () => {
       id: '2-1-1>2-1-3',
       from: '2-1-1',
       to: '2-1-3',
+      parent: '2'
+    },
+    {
+      id: '2-1-2>2-2-1',
+      from: '2-1-2',
+      to: '2-2-1',
       parent: '2'
     },
     {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Nodes that are nested within a nested node cannot be dragged due to findNestedNode returning on an empty object instead of a node object.
Issue Number: N/A


## What is the new behavior?
Properly return when a child node is actually found.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
