### PR TITLE
css not rule applied to multiple classes

### DIFF
--- a/src/symbols/Edge/Edge.module.css
+++ b/src/symbols/Edge/Edge.module.css
@@ -3,8 +3,7 @@
     pointer-events: none;
   }
 
-  &:not(.selectionDisabled),
-  &:not(.disabled) {
+  &:not(.selectionDisabled):not(.disabled) {
     &:hover {
       .path {
         stroke: #a5a9e2;

--- a/src/symbols/Node/Node.module.css
+++ b/src/symbols/Node/Node.module.css
@@ -5,8 +5,7 @@
   shape-rendering: geometricPrecision;
   stroke-width: 1pt;
 
-  &:not(.selectionDisabled),
-  &:not(.disabled) {
+  &:not(.selectionDisabled):not(.disabled) {
     cursor: pointer;
 
     &:hover {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
CSS rules for nodes and edges that have either `selectionDisabled` or `disabled` still have css rules applied to them.
Issue Number: N/A


## What is the new behavior?
Use css `:not` chaining to apply rules to elements without either of the classes

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
