### PR TITLE
use child properties if passed from Node function declaration instead…

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -402,21 +402,13 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
           >
             {layout?.children?.map(({ children, ...n }) => {
               const element = typeof node === 'function' ? node(n) : node;
-              const elementDisabled =
-                element.props?.disabled != null
-                  ? element.props.disabled
-                  : disabled;
-              const elementAnimated =
-                element.props?.animated != null
-                  ? element.props.animated
-                  : animated;
               return (
                 <CloneElement<NodeProps>
                   key={n.id}
                   element={element}
-                  disabled={elementDisabled}
+                  disabled={element.props.disabled != null}
                   children={element.props.children}
-                  animated={elementAnimated}
+                  animated={animated}
                   nodes={children}
                   childEdge={edge}
                   childNode={node}

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -406,7 +406,7 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
                 <CloneElement<NodeProps>
                   key={n.id}
                   element={element}
-                  disabled={element.props.disabled != null}
+                  disabled={disabled}
                   children={element.props.children}
                   animated={animated}
                   nodes={children}

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -402,13 +402,21 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
           >
             {layout?.children?.map(({ children, ...n }) => {
               const element = typeof node === 'function' ? node(n) : node;
+              const elementDisabled =
+                element.props?.disabled != null
+                  ? element.props.disabled
+                  : disabled;
+              const elementAnimated =
+                element.props?.animated != null
+                  ? element.props.animated
+                  : animated;
               return (
                 <CloneElement<NodeProps>
                   key={n.id}
                   element={element}
-                  disabled={disabled}
+                  disabled={elementDisabled}
                   children={element.props.children}
-                  animated={animated}
+                  animated={elementAnimated}
                   nodes={children}
                   childEdge={edge}
                   childNode={node}
@@ -495,56 +503,55 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
   }
 );
 
-export const Canvas: FC<
-  CanvasContainerProps & { ref?: Ref<CanvasRef> }
-> = forwardRef(
-  (
-    {
-      selections = [],
-      readonly = false,
-      fit = false,
-      nodes = [],
-      edges = [],
-      maxHeight = 2000,
-      maxWidth = 2000,
-      direction = 'DOWN',
-      pannable = true,
-      zoom = 1,
-      center = true,
-      zoomable = true,
-      minZoom = -0.5,
-      maxZoom = 1,
-      onNodeLink = () => undefined,
-      onNodeLinkCheck = () => undefined,
-      onLayoutChange = () => undefined,
-      onZoomChange = () => undefined,
-      layoutOptions,
-      ...rest
-    },
-    ref: Ref<CanvasRef>
-  ) => (
-    <CanvasProvider
-      layoutOptions={layoutOptions}
-      nodes={nodes}
-      edges={edges}
-      zoom={zoom}
-      center={center}
-      minZoom={minZoom}
-      maxZoom={maxZoom}
-      fit={fit}
-      maxHeight={maxHeight}
-      maxWidth={maxWidth}
-      direction={direction}
-      pannable={pannable}
-      zoomable={zoomable}
-      readonly={readonly}
-      onLayoutChange={onLayoutChange}
-      selections={selections}
-      onZoomChange={onZoomChange}
-      onNodeLink={onNodeLink}
-      onNodeLinkCheck={onNodeLinkCheck}
-    >
-      <InternalCanvas ref={ref} {...rest} />
-    </CanvasProvider>
-  )
-);
+export const Canvas: FC<CanvasContainerProps & { ref?: Ref<CanvasRef> }> =
+  forwardRef(
+    (
+      {
+        selections = [],
+        readonly = false,
+        fit = false,
+        nodes = [],
+        edges = [],
+        maxHeight = 2000,
+        maxWidth = 2000,
+        direction = 'DOWN',
+        pannable = true,
+        zoom = 1,
+        center = true,
+        zoomable = true,
+        minZoom = -0.5,
+        maxZoom = 1,
+        onNodeLink = () => undefined,
+        onNodeLinkCheck = () => undefined,
+        onLayoutChange = () => undefined,
+        onZoomChange = () => undefined,
+        layoutOptions,
+        ...rest
+      },
+      ref: Ref<CanvasRef>
+    ) => (
+      <CanvasProvider
+        layoutOptions={layoutOptions}
+        nodes={nodes}
+        edges={edges}
+        zoom={zoom}
+        center={center}
+        minZoom={minZoom}
+        maxZoom={maxZoom}
+        fit={fit}
+        maxHeight={maxHeight}
+        maxWidth={maxWidth}
+        direction={direction}
+        pannable={pannable}
+        zoomable={zoomable}
+        readonly={readonly}
+        onLayoutChange={onLayoutChange}
+        selections={selections}
+        onZoomChange={onZoomChange}
+        onNodeLink={onNodeLink}
+        onNodeLinkCheck={onNodeLinkCheck}
+      >
+        <InternalCanvas ref={ref} {...rest} />
+      </CanvasProvider>
+    )
+  );

--- a/src/symbols/Node/Node.tsx
+++ b/src/symbols/Node/Node.tsx
@@ -165,6 +165,7 @@ export const Node: FC<Partial<NodeProps>> = ({
     ? linkable
     : draggable;
   const canSelect = selectable && !properties?.selectionDisabled;
+  console.log(id, draggable, canDrag);
 
   const getDragType = (hasPort: boolean) => {
     let activeDragType: NodeDragType = null;
@@ -423,25 +424,49 @@ export const Node: FC<Partial<NodeProps>> = ({
           nodes.map(({ children, ...n }: any) => {
             const element =
               typeof childNode === 'function' ? childNode(n) : childNode;
+            const elementDisabled =
+              element.props?.disabled != null
+                ? element.props.disabled
+                : disabled;
+            const elementAnimated =
+              element.props?.animated != null
+                ? element.props.animated
+                : animated;
+            const elementDraggable =
+              element.props?.draggable != null
+                ? element.props.draggable
+                : draggable;
+            const elementLinkable =
+              element.props?.linkable != null
+                ? element.props.linkable
+                : linkable;
+            const elementSelectable =
+              element.props?.selectable != null
+                ? element.props.selectable
+                : selectable;
+            const elementRemovable =
+              element.props?.removable != null
+                ? element.props.removable
+                : removable;
             return (
               <CloneElement<NodeProps>
                 key={n.id}
                 element={element}
                 id={`${id}-node-${n.id}`}
-                disabled={isDisabled}
+                disabled={elementDisabled}
                 nodes={children}
                 offsetX={newX}
                 offsetY={newY}
-                animated={animated}
+                animated={elementAnimated}
                 children={element.props.children}
                 childNode={childNode}
                 dragCursor={dragCursor}
                 dragType={dragType}
                 childEdge={childEdge}
-                draggable={draggable}
-                linkable={linkable}
-                selectable={selectable}
-                removable={removable}
+                draggable={elementDraggable}
+                linkable={elementLinkable}
+                selectable={elementSelectable}
+                removable={elementRemovable}
                 onDragStart={onDragStart}
                 onDrag={onDrag}
                 onDragEnd={onDragEnd}

--- a/src/symbols/Node/Node.tsx
+++ b/src/symbols/Node/Node.tsx
@@ -165,7 +165,6 @@ export const Node: FC<Partial<NodeProps>> = ({
     ? linkable
     : draggable;
   const canSelect = selectable && !properties?.selectionDisabled;
-  console.log(id, draggable, canDrag);
 
   const getDragType = (hasPort: boolean) => {
     let activeDragType: NodeDragType = null;

--- a/stories/Drag.stories.tsx
+++ b/stories/Drag.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Canvas } from '../src/Canvas';
-import { Node, Edge, MarkerArrow, Port, Icon, Arrow, Label, Remove, Add } from '../src/symbols';
+import { Node, Edge, MarkerArrow, Port, Icon, Arrow, Label, Remove, Add, NodeProps } from '../src/symbols';
 import { EdgeData, NodeData } from '../src/types';
 import { createEdgeFromNodes, hasLink, removeAndUpsertNodes } from '../src/helpers';
 
@@ -479,7 +479,18 @@ export const NestedNodeRearranging = () => {
       <Canvas
         nodes={nodes}
         edges={edges}
-        node={<Node dragType="node" />}
+        node={(node: NodeProps) => {
+          // Prevent parent nodes with large number of children from dragging, but allow children to drag
+          const children = nodes.filter(n => n.parent && n.parent === node.id);
+          const notDraggable = children.length > 3;
+          return (
+            <Node
+              {...node}
+              dragType="node"
+              draggable={!notDraggable}
+            />
+          );
+        }}
         onNodeLinkCheck={(_event, from: NodeData, to: NodeData) => {
           if (from.id === to.id) {
             return false;


### PR DESCRIPTION
… of parent properties

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If a parent node has draggable set to false, its children node are not draggable due to child properties being determined by parent.
Issue Number: https://github.com/reaviz/reaflow/issues/126


## What is the new behavior?
Use children node properties if present when rendering children nodes. Nested Drag Story demonstrates the change by disallowing dragging on parent nodes with more than 3 children.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
