### PR TITLE
Pass children to edge cloned element

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -431,6 +431,7 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
                   key={e.id}
                   element={element}
                   disabled={disabled}
+                  children={element.props.children}
                   {...e}
                   id={`${id}-edge-${e.id}`}
                 />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When passing children to the <Edge> component as a prop of Canvas, the children get ignored because cloneElement does not copy the children prop. It needs to be explicitly passed along, this was done for the Node case, but not for the Edge case.

Issue Number: N/A

## What is the new behavior?
When passing children to the <Edge> component, they will now get rendered.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

As far as I can tell, this is a bug, but I don't have extensive experience with the codebase. I didn't add any tests as I couldn't find any for this part of the codebase. It's a fairly simple change and shouldn't break anything as far as I can tell.