### PR TITLE
improve edge custom styling

### DIFF
--- a/src/symbols/Edge/Edge.module.css
+++ b/src/symbols/Edge/Edge.module.css
@@ -23,22 +23,22 @@
       cursor: pointer;
     }
   }
+}
 
-  .path {
-    fill: transparent;
-    stroke: #485a74;
-    pointer-events: none;
-    shape-rendering: geometricPrecision;
-    stroke-width: 1pt;
-  }
+.path {
+  fill: transparent;
+  stroke: #485a74;
+  pointer-events: none;
+  shape-rendering: geometricPrecision;
+  stroke-width: 1pt;
+}
 
-  .clicker {
-    fill: none;
-    stroke: transparent;
-    stroke-width: 15px;
+.clicker {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 15px;
 
-    &:focus {
-      outline: none;
-    }
+  &:focus {
+    outline: none;
   }
 }

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -62,7 +62,7 @@ export interface EdgeProps {
   sections: EdgeSections[];
   labels?: LabelProps[];
   className?: string;
-  mainClassName?: string;
+  containerClassName?: string;
 
   add: ReactElement<AddProps, typeof Add>;
   label: ReactElement<LabelProps, typeof Label>;
@@ -96,7 +96,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
   properties,
   labels,
   className,
-  mainClassName,
+  containerClassName,
   disabled,
   removable = true,
   selectable = true,
@@ -176,7 +176,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
 
   return (
     <g
-      className={classNames(css.edge, mainClassName, {
+      className={classNames(css.edge, containerClassName, {
         [css.disabled]: isDisabled,
         [css.selectionDisabled]: !canSelect
       })}

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -62,6 +62,7 @@ export interface EdgeProps {
   sections: EdgeSections[];
   labels?: LabelProps[];
   className?: string;
+  mainClassName?: string;
 
   add: ReactElement<AddProps, typeof Add>;
   label: ReactElement<LabelProps, typeof Label>;
@@ -95,6 +96,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
   properties,
   labels,
   className,
+  mainClassName,
   disabled,
   removable = true,
   selectable = true,
@@ -174,7 +176,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
 
   return (
     <g
-      className={classNames(css.edge, {
+      className={classNames(css.edge, mainClassName, {
         [css.disabled]: isDisabled,
         [css.selectionDisabled]: !canSelect
       })}
@@ -182,7 +184,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
       <path
         ref={pathRef}
         style={style}
-        className={classNames(className, properties?.className, css.path, {
+        className={classNames(css.path, properties?.className, className, {
           [css.active]: isActive,
           [css.deleteHovered]: deleteHovered
         })}

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,7 @@ export interface EdgeData<T = any> {
   /**
    * CSS class name for the edge (main "g" element).
    */
-  mainClassName?: string;
+  containerClassName?: string;
 
   /**
    * Optional arrow head type.

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,9 +134,14 @@ export interface EdgeData<T = any> {
   data?: T;
 
   /**
-   * CSS Classname for the edge.
+   * CSS class name for the edge ("path" element).
    */
   className?: string;
+
+  /**
+   * CSS class name for the edge (main "g" element).
+   */
+  mainClassName?: string;
 
   /**
    * Optional arrow head type.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
it's not possible to style "hover" status for edge.

Issue Number: #138 


## What is the new behavior?
now main Edge component - "g" takes a class "mainClassName", and since the hover fires on "g" you can style the edge itself ("path" element) now. Only with !important due to the weight of the selectors, but this is already something.

Example with regular css:

```
.className {
  stroke: blue;
}

.mainClassName:hover path:first-child {
  stroke: yellow !important;
}
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
