### PR TITLE
Add `elementOrder` prop

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,14 @@ export enum CanvasPosition {
   BOTTOM = 'bottom'
 }
 
+export enum CanvasElement {
+  NODES = 'nodes',
+  EDGES = 'edges',
+  PORTS = 'ports',
+  DRAG_EDGE = 'dragEdge',
+  DRAG_NODE = 'dragNode'
+}
+
 export interface NodeData<T = any> {
   /**
    * Unique ID for the node.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The edges always render on top of the nodes due to SVG positioning.  This causes issues with foreignObject nodes that overflow and in our application should show above the edges.

Issue Number: N/A

## What is the new behavior?
The user can customize the order of the elements using the new `elementOrder` prop, though the default order remains the same. In our application, I can pass in `[CanvasElement.EDGES, CanvasElement.NODES]`, which will only display nodes and edges (we don't use ports or dragging), and will show the nodes above the edges.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```