### PR TITLE
Fix incorrect prop type (arrow)

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -182,7 +182,7 @@ export interface CanvasProps {
   /**
    * Arrow shown on the edges.
    */
-  arrow?: ReactElement<MarkerArrowProps, typeof MarkerArrow>;
+  arrow?: ReactElement<MarkerArrowProps, typeof MarkerArrow> | null;
 
   /**
    * Node or node callback to return element.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
According to [docs](https://reaflow.dev/?path=/story/demos-edges--no-arrows), arrow supposedly can have the `null` value but it's type prevents that.

Issue Number: N/A


## What is the new behavior?
Allow `null` for arrow prop

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
