### PR TITLE
Added interpolation props to Edge

### DIFF
--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -60,6 +60,7 @@ export interface EdgeProps {
   style?: any;
   children?: ReactNode | EdgeChildrenAsFunction;
   sections: EdgeSections[];
+  interpolation: 'linear' | 'curved' | Function;
   labels?: LabelProps[];
   className?: string;
   containerClassName?: string;
@@ -93,6 +94,7 @@ export interface EdgeProps {
 
 export const Edge: FC<Partial<EdgeProps>> = ({
   sections,
+  interpolation = 'curved',
   properties,
   labels,
   className,
@@ -134,17 +136,21 @@ export const Edge: FC<Partial<EdgeProps>> = ({
     if (sections[0].bendPoints) {
       const points: any[] = sections
         ? [
-          sections[0].startPoint,
-          ...(sections[0].bendPoints || ([] as any)),
-          sections[0].endPoint
-        ]
+            sections[0].startPoint,
+            ...(sections[0].bendPoints || ([] as any)),
+            sections[0].endPoint
+          ]
         : [];
 
-      const pathFn = line()
+      let pathFn: any = line()
         .x((d: any) => d.x)
-        .y((d: any) => d.y)
-        .curve(curveBundle.beta(1));
-
+        .y((d: any) => d.y);
+      if (interpolation !== 'linear') {
+        pathFn =
+          interpolation === 'curved'
+            ? pathFn.curve(curveBundle.beta(1))
+            : interpolation;
+      }
       return pathFn(points);
     } else {
       return getBezierPath({

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -94,7 +94,7 @@ export interface EdgeProps {
 
 export const Edge: FC<Partial<EdgeProps>> = ({
   sections,
-  interpolation = 'curved',
+  interpolation,
   properties,
   labels,
   className,
@@ -274,4 +274,8 @@ export const Edge: FC<Partial<EdgeProps>> = ({
       )}
     </g>
   );
+};
+          
+Edge.defaultProps = {
+  interpolation: 'curved'
 };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: 164


## What is the new behavior?
It is now possible to set a new property: 'interpolation', using enums 'linear' or 'curve', or by passing an interpolation function similar to the ones defined [here](https://github.com/d3/d3-shape/blob/main/README.md#curves)


## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```
The default value 'curve' retains the original behaviour
