### PR TITLE
Feature/port to port linking

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -108,7 +108,8 @@ export interface CanvasContainerProps extends CanvasProps {
     event: any,
     fromNode: NodeData,
     toNode: NodeData,
-    fromPort?: PortData
+    fromPort?: PortData,
+    toPort?: PortData
   ) => void;
 
   /**
@@ -118,7 +119,8 @@ export interface CanvasContainerProps extends CanvasProps {
     event: any,
     fromNode: NodeData,
     toNode: NodeData,
-    fromPort?: PortData
+    fromPort?: PortData,
+    toPort?: PortData
   ) => undefined | boolean;
 
   /**

--- a/src/symbols/Node/Node.tsx
+++ b/src/symbols/Node/Node.tsx
@@ -316,6 +316,22 @@ export const Node: FC<Partial<NodeProps>> = ({
     [canvas, isDisabled, onLeave, properties]
   );
 
+  const onPortEnterCallback = useCallback(
+    (event, port: PortData) => {
+      event.stopPropagation();
+      canvas.onEnter(event, properties, port);
+    },
+    [canvas, properties]
+  );
+
+  const onPortLeaveCallback = useCallback(
+    (event, port: PortData) => {
+      event.stopPropagation();
+      canvas.onLeave(event, properties, port);
+    },
+    [canvas, properties]
+  );
+
   const onDragStartCallback = useCallback(
     (event: DragEvent, initial: Position, data: PortData) => {
       if (!isDisabled && linkable) {
@@ -447,6 +463,8 @@ export const Node: FC<Partial<NodeProps>> = ({
             onDragStart={onDragStartCallback}
             onDrag={onDragCallback}
             onDragEnd={onDragEndCallback}
+            onEnter={onPortEnterCallback}
+            onLeave={onPortLeaveCallback}
             {...(p as PortProps)}
             id={`${id}-port-${p.id}`}
           />

--- a/src/symbols/Node/Node.tsx
+++ b/src/symbols/Node/Node.tsx
@@ -43,7 +43,8 @@ export type NodeChildrenAsFunction = (
   nodeChildProps: NodeChildProps
 ) => ReactNode;
 
-export interface NodeProps extends NodeDragEvents<NodeData, PortData> {
+export interface NodeProps<T = any>
+  extends NodeDragEvents<NodeData<T>, PortData> {
   id: string;
   height: number;
   width: number;
@@ -56,7 +57,7 @@ export interface NodeProps extends NodeDragEvents<NodeData, PortData> {
   disabled?: boolean;
   ports?: PortProps[];
   labels?: LabelProps[];
-  properties: any;
+  properties: NodeData<T>;
   className?: string;
   style?: any;
   children?: ReactNode | NodeChildrenAsFunction;

--- a/src/symbols/Port/Port.tsx
+++ b/src/symbols/Port/Port.tsx
@@ -89,7 +89,7 @@ export const Port = forwardRef(
     }: Partial<PortProps>,
     ref: Ref<SVGRectElement>
   ) => {
-    const { readonly } = useCanvas();
+    const { readonly, ...canvas } = useCanvas();
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const [isHovered, setIsHovered] = useState<boolean>(false);
     const newX = x - properties.width / 2;

--- a/src/symbols/Port/Port.tsx
+++ b/src/symbols/Port/Port.tsx
@@ -89,7 +89,7 @@ export const Port = forwardRef(
     }: Partial<PortProps>,
     ref: Ref<SVGRectElement>
   ) => {
-    const { readonly, ...canvas } = useCanvas();
+    const { readonly } = useCanvas();
     const [isDragging, setIsDragging] = useState<boolean>(false);
     const [isHovered, setIsHovered] = useState<boolean>(false);
     const newX = x - properties.width / 2;

--- a/src/utils/useEdgeDrag.ts
+++ b/src/utils/useEdgeDrag.ts
@@ -82,7 +82,6 @@ export const useEdgeDrag = ({
       node: NodeData,
       port?: PortData
     ) => {
-      console.log(node, port, 'NODDDE entre');
       if (dragNode && node) {
         setEnteredNode(node);
         setEnteredPort(port);

--- a/src/utils/useEdgeDrag.ts
+++ b/src/utils/useEdgeDrag.ts
@@ -11,13 +11,16 @@ export interface EdgeDragResult extends NodeDragEvents {
   dragNode: NodeData | null;
   dragPort: PortData | null;
   enteredNode: NodeData | null;
+  enteredPort: PortData | null;
   onEnter?: (
     event: React.MouseEvent<SVGGElement, MouseEvent>,
-    data: NodeData | PortData
+    nodeData: NodeData,
+    portData?: PortData
   ) => void;
   onLeave?: (
     event: React.MouseEvent<SVGGElement, MouseEvent>,
-    data: NodeData | PortData
+    nodeData: NodeData,
+    portData?: PortData
   ) => void;
 }
 
@@ -29,6 +32,7 @@ export const useEdgeDrag = ({
   const [dragPort, setDragPort] = useState<PortData | null>(null);
   const [dragType, setDragType] = useState<NodeDragType | null>(null);
   const [enteredNode, setEnteredNode] = useState<NodeData | null>(null);
+  const [enteredPort, setEnteredPort] = useState<PortData | null>(null);
   const [dragCoords, setDragCoords] = useState<EdgeSections[] | null>(null);
   const [canLinkNode, setCanLinkNode] = useState<boolean | null>(null);
 
@@ -60,22 +64,29 @@ export const useEdgeDrag = ({
   const onDragEnd = useCallback(
     (event: DragEvent) => {
       if (dragNode && enteredNode && canLinkNode) {
-        onNodeLink(event, dragNode, enteredNode, dragPort);
+        onNodeLink(event, dragNode, enteredNode, dragPort, enteredPort);
       }
 
       setDragNode(null);
       setDragPort(null);
       setEnteredNode(null);
+      setEnteredPort(null);
       setDragCoords(null);
     },
-    [canLinkNode, dragNode, dragPort, enteredNode, onNodeLink]
+    [canLinkNode, dragNode, dragPort, enteredNode, enteredPort, onNodeLink]
   );
 
   const onEnter = useCallback(
-    (event: React.MouseEvent<SVGGElement, MouseEvent>, node: NodeData) => {
+    (
+      event: React.MouseEvent<SVGGElement, MouseEvent>,
+      node: NodeData,
+      port?: PortData
+    ) => {
+      console.log(node, port, 'NODDDE entre');
       if (dragNode && node) {
         setEnteredNode(node);
-        const canLink = onNodeLinkCheck(event, dragNode, node, dragPort);
+        setEnteredPort(port);
+        const canLink = onNodeLinkCheck(event, dragNode, node, dragPort, port);
         const result =
           (canLink === undefined || canLink) &&
           (dragNode.parent === node.parent || dragType === 'node');
@@ -87,13 +98,22 @@ export const useEdgeDrag = ({
   );
 
   const onLeave = useCallback(
-    (event: React.MouseEvent<SVGGElement, MouseEvent>, node: NodeData) => {
+    (
+      event: React.MouseEvent<SVGGElement, MouseEvent>,
+      node: NodeData,
+      port?: PortData
+    ) => {
       if (dragNode && node) {
         setEnteredNode(null);
         setCanLinkNode(null);
       }
+
+      if (dragPort && port) {
+        setEnteredPort(null);
+        setCanLinkNode(null);
+      }
     },
-    [dragNode]
+    [dragNode, dragPort]
   );
 
   return {
@@ -102,6 +122,7 @@ export const useEdgeDrag = ({
     dragNode,
     dragPort,
     enteredNode,
+    enteredPort,
     onDragStart,
     onDrag,
     onDragEnd,

--- a/stories/Port.stories.tsx
+++ b/stories/Port.stories.tsx
@@ -104,6 +104,60 @@ export const Simple = () => (
   </div>
 );
 
+export const LinkingPortToPort = () => (
+  <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}>
+    <Canvas
+      nodes={[
+        {
+          id: '1',
+          text: 'Node 1',
+          ports: [
+            {
+              id: '1-from',
+              width: 10,
+              height: 10,
+              side: 'SOUTH'
+            },
+            {
+              id: '1-to',
+              width: 10,
+              height: 10,
+              side: 'NORTH'
+            }
+          ]
+        },
+        {
+          id: '2',
+          text: 'Node 2',
+          ports: [
+            {
+              id: '2-from',
+              width: 10,
+              height: 10,
+              side: 'SOUTH'
+            },
+            {
+              id: '2-to',
+              width: 10,
+              height: 10,
+              side: 'NORTH'
+            }
+          ]
+        }
+      ]}
+      edges={[]}
+      node={<Node dragType="port" />}
+      onNodeLinkCheck={(_e, _fromNode, _toNode, _fromPort, toPort) => {
+        // Only allow port to port dragging
+        return toPort !== undefined;
+      }}
+      onNodeLink={(_e, fromNode, toNode, fromPort, toPort) => {
+        alert(`${fromNode.id}.${fromPort.side} -> ${toNode.id}.${toPort.side}`);
+      }}
+    />
+  </div>
+);
+
 export const Disabled = () => (
   <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }}>
     <Canvas
@@ -395,7 +449,12 @@ export const LinkingPortRestrictions = () => {
       <Canvas
         nodes={nodes}
         edges={edges}
-        onNodeLinkCheck={(_event, from: NodeData, to: NodeData, port: PortData) => {
+        onNodeLinkCheck={(
+          _event,
+          from: NodeData,
+          to: NodeData,
+          port: PortData
+        ) => {
           if (from.id === to.id || to.id === '1') {
             return false;
           }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) (story example)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently you cannot easily link from one port to another.
You have to implement the correct event listeners yourself by overriding the custom `Port` component and set the event listeners manually.

See #114 

## What is the new behavior?
This PR builds on top of the existing `onNodeLinkCheck` and `onNodeLink` API's and adds the `toPort` parameter to each.

```typescript
  onNodeLink?: (
    event: any,
    fromNode: NodeData,
    toNode: NodeData,
    fromPort?: PortData,
    toPort?: PortData         // <-- added
  ) => void;

  onNodeLinkCheck?: (
    event: any,
    fromNode: NodeData,
    toNode: NodeData,
    fromPort?: PortData,
    toPort?: PortData         // <-- added
  ) => undefined | boolean;
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No, it should not be a breaking change
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
