### PR TITLE
Fix getCoords when non-center position is used

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,5 @@
 import { RefObject } from 'react';
 import { NodeData } from '../types';
-import { ElkRoot } from '../layout';
 import { Matrix2D } from 'kld-affine';
 
 /**
@@ -29,10 +28,7 @@ export function checkNodeLinkable(
 
 export interface CoordProps {
   zoom: number;
-  scrollXY: [number, number];
-  layout: ElkRoot;
-  containerWidth: number;
-  containerHeight: number;
+  layoutXY: [number, number];
   containerRef: RefObject<HTMLDivElement | null>;
 }
 
@@ -40,20 +36,10 @@ export interface CoordProps {
  * Given various dimensions and positions, create a matrix
  * used for determining position.
  */
-export function getCoords({
-  zoom,
-  scrollXY,
-  layout,
-  containerWidth,
-  containerHeight,
-  containerRef
-}: CoordProps) {
+export function getCoords({ zoom, layoutXY, containerRef }: CoordProps) {
   const { top, left } = containerRef.current.getBoundingClientRect();
-  const offsetX = scrollXY[0] - containerRef.current.scrollLeft;
-  const offsetY = scrollXY[1] - containerRef.current.scrollTop;
-
-  const tx = (containerWidth - layout.width * zoom) / 2 + offsetX + left;
-  const ty = (containerHeight - layout.height * zoom) / 2 + offsetY + top;
+  const tx = layoutXY[0] - containerRef.current.scrollLeft + left;
+  const ty = layoutXY[1] - containerRef.current.scrollTop + top;
 
   return new Matrix2D().translate(tx, ty).scale(zoom).inverse();
 }
@@ -84,9 +70,7 @@ export function findNestedNode(
   }
 
   // Check for nested children
-  const nodesWithChildren = children.filter(
-    n => n.children?.length
-  );
+  const nodesWithChildren = children.filter(n => n.children?.length);
   // Iterate over all nested nodes and check if any of them contain the node
   for (const n of nodesWithChildren) {
     const foundChild = findNestedNode(nodeId, n.children, parentId);

--- a/src/utils/useNodeDrag.ts
+++ b/src/utils/useNodeDrag.ts
@@ -47,14 +47,7 @@ export const useNodeDrag = ({
 }: NodeDragProps) => {
   const initial: Position = [width / 2 + x, height + y];
   const targetRef = useRef<EventTarget | null>(null);
-  const {
-    zoom,
-    scrollXY,
-    layout,
-    containerWidth,
-    containerRef,
-    containerHeight
-  } = useCanvas();
+  const { zoom, xy, containerRef } = useCanvas();
 
   const bind = useDrag(
     state => {
@@ -70,10 +63,7 @@ export const useNodeDrag = ({
         const matrix = getCoords({
           containerRef,
           zoom,
-          layout,
-          scrollXY,
-          containerHeight,
-          containerWidth
+          layoutXY: xy
         });
 
         // memo will hold the difference between the


### PR DESCRIPTION
## Description

This is related to the last PR I made: https://github.com/reaviz/reaflow/pull/154

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When the `position` is not `center`, `getCoords` returns the wrong transformation, and so the drag edge does not point to the cursor


## What is the new behavior?
The drag edge always follows the cursor correctly when various `position`'s are used. After doing some light algebra, it turns out `getCoords` could be greatly simplified by using the `xy` from `useLayout`, which already takes `position` into account.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
