### PR TITLE
Feature/expose useScrollXY function

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -254,6 +254,7 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
       zoomOut,
       positionCanvas,
       fitCanvas,
+      setScrollXY,
       ...rest
     } = useCanvas();
     const [dragType, setDragType] = useState<null | NodeDragType>(null);
@@ -272,7 +273,8 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
       setZoom,
       zoomIn,
       zoomOut,
-      fitCanvas
+      fitCanvas,
+      setScrollXY
     }));
 
     const mount = useRef<boolean>(false);

--- a/src/layout/useLayout.ts
+++ b/src/layout/useLayout.ts
@@ -91,6 +91,11 @@ export interface LayoutResult {
    */
   fitCanvas?: () => void;
 
+  /**
+   * Scroll to X/Y
+   */
+  setScrollXY?: (xy: [number, number]) => void;
+
   observe: (el: HTMLDivElement) => void;
 }
 
@@ -272,6 +277,7 @@ export const useLayout = ({
     layout,
     scrollXY,
     positionCanvas,
-    fitCanvas
+    fitCanvas,
+    setScrollXY
   } as LayoutResult;
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, you cannot set scroll position using any exported method and hence cannot focus or centre around a node using x/y, based on our own business logic.

See [#64](https://github.com/reaviz/reaflow/issues/64#issuecomment-779863073)


## What is the new behavior?
This PR exposes the setScrollXY and makes it available in the useLayout hook and canvas ref.
We tested it in our app, and it is working fine for searching and focusing on a specific node:
https://www.awesomescreenshot.com/video/11160447?key=8efe018ff612b72e4e00121945992aea

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No, it should not be a breaking change
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
