### PR TITLE
Feature - Marker arrows now match the hover styling of the edges.

### DIFF
--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -21,7 +21,13 @@ import {
   LayoutResult,
   ElkCanvasLayoutOptions
 } from './layout';
-import { MarkerArrow, MarkerArrowProps } from './symbols/Arrow';
+import {
+  MarkerArrow,
+  MarkerArrowActive,
+  MarkerArrowDelete,
+  MarkerArrowHover,
+  MarkerArrowProps
+} from './symbols/Arrow';
 import { CanvasPosition, EdgeData, NodeData, PortData } from './types';
 import classNames from 'classnames';
 import { CanvasProvider, useCanvas } from './utils/CanvasProvider';
@@ -185,6 +191,11 @@ export interface CanvasProps {
   arrow?: ReactElement<MarkerArrowProps, typeof MarkerArrow> | null;
 
   /**
+   * Arrow shown on a hovered edges.
+   */
+  arrowHover?: ReactElement<MarkerArrowProps, typeof MarkerArrow> | null;
+
+  /**
    * Node or node callback to return element.
    */
   node?:
@@ -226,6 +237,7 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
       disabled = false,
       animated = true,
       arrow = <MarkerArrow />,
+      arrowHover = <MarkerArrowHover />,
       node = <Node />,
       edge = <Edge />,
       dragNode = <Node />,
@@ -371,12 +383,30 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
           width={canvasWidth}
           onClick={onCanvasClick}
         >
-          {arrow !== null && (
+          {arrow !== null && arrowHover !== null && (
             <defs>
-              <CloneElement<MarkerArrowProps>
-                element={arrow}
-                {...(arrow as MarkerArrowProps)}
-              />
+              <React.Fragment key={`${id}-arrow`}>
+                <CloneElement<MarkerArrowProps>
+                  element={arrow}
+                  {...(arrow as MarkerArrowProps)}
+                />
+              </React.Fragment>
+              <React.Fragment key={`${id}-arrow-hover`}>
+                <CloneElement<MarkerArrowProps>
+                  element={arrowHover}
+                  {...(arrowHover as MarkerArrowProps)}
+                />
+              </React.Fragment>
+              <React.Fragment key={`${id}-arrow-hover-active`}>
+                <CloneElement<MarkerArrowProps>
+                  element={<MarkerArrowActive />}
+                />
+              </React.Fragment>
+              <React.Fragment key={`${id}-arrow-hover-delete`}>
+                <CloneElement<MarkerArrowProps>
+                  element={<MarkerArrowDelete />}
+                />
+              </React.Fragment>
             </defs>
           )}
           <motion.g

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -385,28 +385,28 @@ const InternalCanvas: FC<CanvasProps & { ref?: Ref<CanvasRef> }> = forwardRef(
         >
           {arrow !== null && arrowHover !== null && (
             <defs>
-              <React.Fragment key={`${id}-arrow`}>
+              <Fragment key={`${id}-arrow`}>
                 <CloneElement<MarkerArrowProps>
                   element={arrow}
                   {...(arrow as MarkerArrowProps)}
                 />
-              </React.Fragment>
-              <React.Fragment key={`${id}-arrow-hover`}>
+              </Fragment>
+              <Fragment key={`${id}-arrow-hover`}>
                 <CloneElement<MarkerArrowProps>
                   element={arrowHover}
                   {...(arrowHover as MarkerArrowProps)}
                 />
-              </React.Fragment>
-              <React.Fragment key={`${id}-arrow-hover-active`}>
+              </Fragment>
+              <Fragment key={`${id}-arrow-hover-active`}>
                 <CloneElement<MarkerArrowProps>
                   element={<MarkerArrowActive />}
                 />
-              </React.Fragment>
-              <React.Fragment key={`${id}-arrow-hover-delete`}>
+              </Fragment>
+              <Fragment key={`${id}-arrow-hover-delete`}>
                 <CloneElement<MarkerArrowProps>
                   element={<MarkerArrowDelete />}
                 />
-              </React.Fragment>
+              </Fragment>
             </defs>
           )}
           <motion.g

--- a/src/symbols/Arrow/Arrow.module.css
+++ b/src/symbols/Arrow/Arrow.module.css
@@ -4,14 +4,14 @@
   fill: #485a74;
 }
 
-.arrow__hover {
+.arrowHover {
   fill: #a5a9e2;
 }
 
-.arrow__hover--active {
+.arrowHoverActive {
   fill: #46fecb;
 }
 
-.arrow__hover--delete {
+.arrowHoverDelete {
   fill: #ff005d;
 }

--- a/src/symbols/Arrow/Arrow.module.css
+++ b/src/symbols/Arrow/Arrow.module.css
@@ -3,3 +3,15 @@
   shape-rendering: geometricPrecision;
   fill: #485a74;
 }
+
+.arrow__hover {
+  fill: #a5a9e2;
+}
+
+.arrow__hover--active {
+  fill: #46fecb;
+}
+
+.arrow__hover--delete {
+  fill: #ff005d;
+}

--- a/src/symbols/Arrow/MarkerArrow.tsx
+++ b/src/symbols/Arrow/MarkerArrow.tsx
@@ -1,5 +1,7 @@
+import classNames from 'classnames';
 import React, { FC } from 'react';
 import { Arrow } from './Arrow';
+import css from './Arrow.module.css';
 
 export interface MarkerArrowProps {
   size?: number;
@@ -7,14 +9,15 @@ export interface MarkerArrowProps {
   className?: string;
 }
 
-export const MarkerArrow: FC<Partial<MarkerArrowProps>> = ({
+const MarkerArrowBase: FC<Partial<MarkerArrowProps>> = ({
   size = 8,
   className,
-  style
+  style,
+  id
 }) => (
   <marker
-    id="end-arrow"
-    key="end-arrow"
+    id={id}
+    key={id}
     viewBox={`0 -${size / 2} ${size} ${size}`}
     refX={`${size}`}
     markerWidth={`${size}`}
@@ -23,4 +26,50 @@ export const MarkerArrow: FC<Partial<MarkerArrowProps>> = ({
   >
     <Arrow size={size} style={style} className={className} />
   </marker>
+);
+
+export const MarkerArrow: FC<Partial<MarkerArrowProps>> = ({
+  size = 8,
+  className,
+  style
+}) => (
+  <MarkerArrowBase
+    id="end-arrow"
+    size={size}
+    className={className}
+    style={style}
+  />
+);
+
+export const MarkerArrowHover: FC<Partial<MarkerArrowProps>> = ({
+  size = 8,
+  className,
+  style
+}) => (
+  <MarkerArrowBase
+    id="end-arrow-hover"
+    size={size}
+    className={classNames(css['arrow__hover'], className)}
+    style={style}
+  />
+);
+
+export const MarkerArrowActive: FC<Partial<MarkerArrowProps>> = ({
+  size = 8
+}) => (
+  <MarkerArrowBase
+    id="end-arrow-hover-active"
+    size={size}
+    className={classNames(css['arrow__hover--active'])}
+  />
+);
+
+export const MarkerArrowDelete: FC<Partial<MarkerArrowProps>> = ({
+  size = 8
+}) => (
+  <MarkerArrowBase
+    id="end-arrow-hover-delete"
+    size={size}
+    className={classNames(css['arrow__hover--delete'])}
+  />
 );

--- a/src/symbols/Arrow/MarkerArrow.tsx
+++ b/src/symbols/Arrow/MarkerArrow.tsx
@@ -50,7 +50,7 @@ export const MarkerArrowHover: FC<Partial<MarkerArrowProps>> = ({
   <MarkerArrowBase
     markerEndId="end-arrow-hover"
     size={size}
-    className={classNames(css['arrow__hover'], className)}
+    className={classNames(css.arrowHover, className)}
     style={style}
   />
 );
@@ -61,7 +61,7 @@ export const MarkerArrowActive: FC<Partial<MarkerArrowProps>> = ({
   <MarkerArrowBase
     markerEndId="end-arrow-hover-active"
     size={size}
-    className={classNames(css['arrow__hover--active'])}
+    className={classNames(css.arrowHoverActive)}
   />
 );
 
@@ -71,6 +71,6 @@ export const MarkerArrowDelete: FC<Partial<MarkerArrowProps>> = ({
   <MarkerArrowBase
     markerEndId="end-arrow-hover-delete"
     size={size}
-    className={classNames(css['arrow__hover--delete'])}
+    className={classNames(css.arrowHoverDelete)}
   />
 );

--- a/src/symbols/Arrow/MarkerArrow.tsx
+++ b/src/symbols/Arrow/MarkerArrow.tsx
@@ -7,17 +7,18 @@ export interface MarkerArrowProps {
   size?: number;
   style?: any;
   className?: string;
+  markerEndId?: string;
 }
 
 const MarkerArrowBase: FC<Partial<MarkerArrowProps>> = ({
   size = 8,
   className,
   style,
-  id
+  markerEndId
 }) => (
   <marker
-    id={id}
-    key={id}
+    id={markerEndId}
+    key={markerEndId}
     viewBox={`0 -${size / 2} ${size} ${size}`}
     refX={`${size}`}
     markerWidth={`${size}`}
@@ -34,7 +35,7 @@ export const MarkerArrow: FC<Partial<MarkerArrowProps>> = ({
   style
 }) => (
   <MarkerArrowBase
-    id="end-arrow"
+    markerEndId="end-arrow"
     size={size}
     className={className}
     style={style}
@@ -47,7 +48,7 @@ export const MarkerArrowHover: FC<Partial<MarkerArrowProps>> = ({
   style
 }) => (
   <MarkerArrowBase
-    id="end-arrow-hover"
+    markerEndId="end-arrow-hover"
     size={size}
     className={classNames(css['arrow__hover'], className)}
     style={style}
@@ -58,7 +59,7 @@ export const MarkerArrowActive: FC<Partial<MarkerArrowProps>> = ({
   size = 8
 }) => (
   <MarkerArrowBase
-    id="end-arrow-hover-active"
+    markerEndId="end-arrow-hover-active"
     size={size}
     className={classNames(css['arrow__hover--active'])}
   />
@@ -68,7 +69,7 @@ export const MarkerArrowDelete: FC<Partial<MarkerArrowProps>> = ({
   size = 8
 }) => (
   <MarkerArrowBase
-    id="end-arrow-hover-delete"
+    markerEndId="end-arrow-hover-delete"
     size={size}
     className={classNames(css['arrow__hover--delete'])}
   />

--- a/src/symbols/Edge/Edge.module.css
+++ b/src/symbols/Edge/Edge.module.css
@@ -6,13 +6,16 @@
   &:not(.selectionDisabled):not(.disabled) {
     &:hover {
       .path {
+        marker-end: url(#end-arrow-hover);
         stroke: #a5a9e2;
 
         &.active {
+          marker-end: url(#end-arrow-hover-active);
           stroke: #46fecb;
         }
 
         &.deleteHovered {
+          marker-end: url(#end-arrow-hover-delete);
           stroke: #ff005d;
           stroke-dasharray: 4 2;
         }
@@ -27,6 +30,7 @@
 
 .path {
   fill: transparent;
+  marker-end: url(#end-arrow);
   stroke: #485a74;
   pointer-events: none;
   shape-rendering: geometricPrecision;

--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -136,10 +136,10 @@ export const Edge: FC<Partial<EdgeProps>> = ({
     if (sections[0].bendPoints) {
       const points: any[] = sections
         ? [
-            sections[0].startPoint,
-            ...(sections[0].bendPoints || ([] as any)),
-            sections[0].endPoint
-          ]
+          sections[0].startPoint,
+          ...(sections[0].bendPoints || ([] as any)),
+          sections[0].endPoint
+        ]
         : [];
 
       let pathFn: any = line()
@@ -195,7 +195,6 @@ export const Edge: FC<Partial<EdgeProps>> = ({
           [css.deleteHovered]: deleteHovered
         })}
         d={d}
-        markerEnd="url(#end-arrow)"
       />
       <path
         className={css.clicker}
@@ -275,7 +274,7 @@ export const Edge: FC<Partial<EdgeProps>> = ({
     </g>
   );
 };
-          
+
 Edge.defaultProps = {
   interpolation: 'curved'
 };

--- a/stories/Basic.stories.tsx
+++ b/stories/Basic.stories.tsx
@@ -688,6 +688,7 @@ export const ManyNodes = () => {
         dragNode={null}
         dragEdge={null}
         arrow={<Arrow />}
+        arrowHover={<Arrow />}
         node={
           <Node
             dragType="node"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
On hover of an edge, the marker arrow does not match the edge hover color. This was a feature request over in the JSON Crack repo: [JSON Crack Issue 236](https://github.com/AykutSarac/jsoncrack.com/issues/236)

![reaflow-marker-before](https://user-images.githubusercontent.com/14914689/216832621-09968dd6-1a18-4c7b-b4d4-57330de536c5.gif)


Issue Number: N/A


## What is the new behavior?

On hover of an edge, the marker will now match the edge color for default, active and disabled edge states.

![reaflow-marker-after](https://user-images.githubusercontent.com/14914689/216832690-82f5b868-dfbc-475c-8c45-0422c5cccfb7.gif)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Adding dynamic styling to marker ends does required individual markers to be defined. I was able to solve for the default behavior while allowing users to define their own hover marker for anything custom.


