### PR TITLE
refactor: use default parameter of interpolation instead of deprecate…

### DIFF
--- a/src/symbols/Edge/Edge.tsx
+++ b/src/symbols/Edge/Edge.tsx
@@ -94,7 +94,7 @@ export interface EdgeProps {
 
 export const Edge: FC<Partial<EdgeProps>> = ({
   sections,
-  interpolation,
+  interpolation = 'curved',
   properties,
   labels,
   className,
@@ -276,6 +276,3 @@ export const Edge: FC<Partial<EdgeProps>> = ({
   );
 };
           
-Edge.defaultProps = {
-  interpolation: 'curved'
-};


### PR DESCRIPTION
defaultProps API is deprecated after react 18 version.
here related pr and text log

-  [react-deprecate-defaultprops-on-function-components](https://github.com/reactjs/rfcs/blob/createlement-rfc/text/0000-create-element-changes.md#deprecate-defaultprops-on-function-components)
- https://github.com/facebook/react/pull/25699

So I delete defaultProps in code.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

### Warning message
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![스크린샷 2023-05-16 오전 10 29 37](https://github.com/reaviz/reaflow/assets/55486644/6d9326c8-ae3a-43ea-ad5c-a7b03ed6f586)

### Warning line
![스크린샷 2023-05-16 오전 10 31 56](https://github.com/reaviz/reaflow/assets/55486644/7aa274f0-5345-44fc-bc63-d3f3e6dd7cb5)

Issue Number: N/A


## What is the new behavior?
- use default parameter 'curved' instead of defaultProps in Edge function
- no longer print Warning message


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
