### PR TITLE
Fix webpack error

### DIFF
--- a/src/layout/utils.ts
+++ b/src/layout/utils.ts
@@ -12,7 +12,8 @@ export function measureText(text: string) {
   let result = { height: 0, width: 0 };
 
   if (text) {
-    result = calculateSize(text, {
+    // @ts-ignore
+    result = calculateSize.default(text, {
       font: 'Arial, sans-serif',
       fontSize: '14px'
     });


### PR DESCRIPTION
## PR Type
Fixes #225
Fixes #228

For some reason `calculateSize` can be accessed via `.default`
## PR Checklist

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

I'd recommend trying locally before merging.