### PR TITLE
fix: elk.bundled webpack error

### DIFF
--- a/src/layout/elkLayout.ts
+++ b/src/layout/elkLayout.ts
@@ -1,5 +1,5 @@
 import { EdgeData, NodeData } from '../types';
-import ELK, { ElkNode } from 'elkjs/lib/elk.bundled';
+import ELK, { ElkNode } from 'elkjs/lib/elk.bundled.js';
 import PCancelable from 'p-cancelable';
 import { formatText, measureText } from './utils';
 


### PR DESCRIPTION
Objective: Since 5.2.0 switch to Vite, the dist folder has become a type=module. But at this line 18: the bundled code is referenced directly without extension. Adding the extension resolves webpack resolution error when using reaflow as library.
Functionally, there would be no change introduced.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Resolves #223 without adding webpack config change.

Issue Number: #223 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
