### PR TITLE
fix: Center horizontal edge labels

### DIFF
--- a/src/layout/elkLayout.ts
+++ b/src/layout/elkLayout.ts
@@ -192,7 +192,7 @@ function mapNode(nodes: NodeData[], edges: EdgeData[], node: NodeData) {
 
   const children = nodes.filter((n) => n.parent === node.id).map((n) => mapNode(nodes, edges, n));
 
-  const childEdges = edges.filter((e) => e.parent === node.id).map((e) => mapEdge(e));
+  const childEdges = edges.filter((e) => e.parent === node.id).map((e) => mapEdge({ edge: e }));
 
   const nodeLayoutOptions: ElkNodeLayoutOptions = {
     'elk.padding': `[left=${nodePadding.left}, top=${nodePadding.top}, right=${nodePadding.right}, bottom=${nodePadding.bottom}]`,
@@ -234,9 +234,14 @@ function mapNode(nodes: NodeData[], edges: EdgeData[], node: NodeData) {
   };
 }
 
-function mapEdge({ data, ...edge }: EdgeData) {
+function mapEdge({ edge: { data, ...edge }, direction }: { edge: EdgeData; direction?: CanvasDirection }) {
   const labelDim = measureText(edge.text);
   const validEdgeData = data ? { data } : {};
+  let labelWidth = labelDim.width / 2;
+
+  if (direction === 'LEFT' || direction === 'RIGHT') {
+    labelWidth = labelDim.width;
+  }
 
   return {
     id: edge.id,
@@ -251,7 +256,7 @@ function mapEdge({ data, ...edge }: EdgeData) {
     labels: edge.text
       ? [
         {
-          width: labelDim.width / 2,
+          width: labelWidth,
           height: -(labelDim.height / 2),
           text: edge.text,
           layoutOptions: {
@@ -263,7 +268,7 @@ function mapEdge({ data, ...edge }: EdgeData) {
   };
 }
 
-function mapInput(nodes: NodeData[], edges: EdgeData[]) {
+function mapInput({ nodes, edges, direction }: { nodes: NodeData[]; edges: EdgeData[]; direction?: CanvasDirection }) {
   const children = [];
   const mappedEdges = [];
 
@@ -278,7 +283,7 @@ function mapInput(nodes: NodeData[], edges: EdgeData[]) {
 
   for (const edge of edges) {
     if (!edge.parent) {
-      const mappedEdge = mapEdge(edge);
+      const mappedEdge = mapEdge({ edge, direction });
       if (mappedEdge !== null) {
         mappedEdges.push(mappedEdge);
       }
@@ -328,7 +333,7 @@ export const elkLayout = (nodes: NodeData[], edges: EdgeData[], options: ElkCanv
       .layout(
         {
           id: 'root',
-          ...mapInput(nodes, edges)
+          ...mapInput({ nodes, edges, direction: layoutOptions?.['elk.direction'] })
         },
         {
           layoutOptions: layoutOptions


### PR DESCRIPTION
This fixes the width calculation for horizontal edge labels so they're centered

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Improvement
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Horizontal edge labels are to the right of center along the edge/line connecting two nodes. This is more obvious the longer the label is

Issue Number: N/A


## What is the new behavior?
Horizontal edge labels are now centered along the edge

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
**BEFORE**
![Screenshot 2023-11-07 at 9 25 44 AM](https://github.com/reaviz/reaflow/assets/40581813/94e4fef3-7e31-4db5-8d07-d325dbfa86d1)
![Screenshot 2023-11-07 at 8 48 01 AM](https://github.com/reaviz/reaflow/assets/40581813/6fe96b42-089e-48d8-9351-1f5875172383)

**AFTER**
![Screenshot 2023-11-07 at 9 25 59 AM](https://github.com/reaviz/reaflow/assets/40581813/9621c8c1-a783-4b24-848c-b7b422864fa5)
![Screenshot 2023-11-07 at 8 48 13 AM](https://github.com/reaviz/reaflow/assets/40581813/c05f2e5c-d175-4371-8030-ce0ddb76e1d2)

